### PR TITLE
データベース初期化用のファイルを追加

### DIFF
--- a/db.cnf
+++ b/db.cnf
@@ -1,0 +1,6 @@
+[client]
+default-character-set=utf8mb4
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+default-time-zone='Asia/Tokyo'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
     volumes:
       - /var/lib/mysql
       - /docker-entrypoint-initdb.datasource
+      - ./db.cnf:/etc/my.cnf
 
   flyway-clean:
     <<: *flyway-template

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -40,9 +40,11 @@ CREATE TABLE `favorites`
   COLLATE = utf8mb4_unicode_ci COMMENT = 'いいねテーブル';
 
 -- データ挿入
+# ユーザーデータ
 INSERT INTO users (username, email, password)
 VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta'),
        ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
+# 投稿データ
 INSERT INTO posts (user_id, text)
 VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎'),
        (2, '今日の晩御飯はまずかった。 by 田中花子');

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -1,13 +1,39 @@
 -- テーブル作成
--- ユーザマスタ
-CREATE TABLE m_user
-(
-    id                        int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
-    created_at                datetime            DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-    updated_at                datetime            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-    deleted_at                datetime            DEFAULT NULL COMMENT '削除日時',
-    PRIMARY KEY (id)
-) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='ユーザマスタ'
-;
+-- ユーザーテーブル
+CREATE TABLE `users` (
+                         `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+                         `username` VARCHAR(256) NOT NULL COMMENT 'ユーザーID',
+                         `email` VARCHAR(256) NOT NULL COMMENT 'メールアドレス',
+                         `password` VARCHAR(256) NOT NULL COMMENT 'パスワード',
+                         `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+                         `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+                         `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+                         PRIMARY KEY (id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'ユーザーテーブル';
+-- 投稿テーブル
+CREATE TABLE `posts` (
+                         `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+                         `user_id` int unsigned NOT NULL COMMENT '投稿者ユーザーID',
+                         `text` VARCHAR(140) NOT NULL COMMENT '投稿本文',
+                         `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+                         `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+                         `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+                         PRIMARY KEY (id),
+                         FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = '投稿テーブル';
+-- いいねテーブル
+CREATE TABLE `favorites` (
+                             `user_id` int unsigned NOT NULL COMMENT 'ユーザーID',
+                             `post_id` int unsigned NOT NULL COMMENT '投稿ID',
+                             FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+                             FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),
+                             PRIMARY KEY (`user_id`, `post_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'いいねテーブル';
+
+-- データ挿入
+INSERT INTO users (username, email, password) VALUES ('山田太郎', 'test@example.com', 'pass123');
+INSERT INTO users (username, email, password) VALUES ('田中花子', 'test2@example.com', 'pass123');
+INSERT INTO posts (user_id, text) VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎');
+INSERT INTO posts (user_id, text) VALUES (2, '今日の晩御飯はまずかった。 by 田中花子');
+# 太郎から花子の投稿へのいいね
+INSERT INTO favorites (user_id, post_id) VALUES (1, 2)

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -41,13 +41,11 @@ CREATE TABLE `favorites`
 
 -- データ挿入
 INSERT INTO users (username, email, password)
-VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
-INSERT INTO users (username, email, password)
-VALUES ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
+VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta'),
+       ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
 INSERT INTO posts (user_id, text)
-VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎');
-INSERT INTO posts (user_id, text)
-VALUES (2, '今日の晩御飯はまずかった。 by 田中花子');
+VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎'),
+       (2, '今日の晩御飯はまずかった。 by 田中花子');
 # 太郎から花子の投稿へのいいね
 INSERT INTO favorites (user_id, post_id)
 VALUES (1, 2)

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -48,4 +48,4 @@ VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎'),
        (2, '今日の晩御飯はまずかった。 by 田中花子');
 # 太郎から花子の投稿へのいいね
 INSERT INTO favorites (user_id, post_id)
-VALUES (1, 2)
+VALUES (1, 2);

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -1,10 +1,10 @@
 -- テーブル作成
 -- ユーザーテーブル
 CREATE TABLE `users` (
-                         `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+                         `id` int NOT NULL AUTO_INCREMENT COMMENT 'ID',
                          `username` VARCHAR(256) NOT NULL COMMENT 'ユーザーID',
                          `email` VARCHAR(256) NOT NULL COMMENT 'メールアドレス',
-                         `password` VARCHAR(256) NOT NULL COMMENT 'パスワード',
+                         `password` BINARY(60) NOT NULL COMMENT 'パスワード (BCrypt)',
                          `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
                          `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
                          `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
@@ -12,8 +12,8 @@ CREATE TABLE `users` (
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'ユーザーテーブル';
 -- 投稿テーブル
 CREATE TABLE `posts` (
-                         `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
-                         `user_id` int unsigned NOT NULL COMMENT '投稿者ユーザーID',
+                         `id` int NOT NULL AUTO_INCREMENT COMMENT 'ID',
+                         `user_id` int NOT NULL COMMENT '投稿者ユーザーID',
                          `text` VARCHAR(140) NOT NULL COMMENT '投稿本文',
                          `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
                          `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
@@ -23,16 +23,16 @@ CREATE TABLE `posts` (
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = '投稿テーブル';
 -- いいねテーブル
 CREATE TABLE `favorites` (
-                             `user_id` int unsigned NOT NULL COMMENT 'ユーザーID',
-                             `post_id` int unsigned NOT NULL COMMENT '投稿ID',
+                             `user_id` int NOT NULL COMMENT 'ユーザーID',
+                             `post_id` int NOT NULL COMMENT '投稿ID',
                              FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
                              FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),
                              PRIMARY KEY (`user_id`, `post_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'いいねテーブル';
 
 -- データ挿入
-INSERT INTO users (username, email, password) VALUES ('山田太郎', 'test@example.com', 'pass123');
-INSERT INTO users (username, email, password) VALUES ('田中花子', 'test2@example.com', 'pass123');
+INSERT INTO users (username, email, password) VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
+INSERT INTO users (username, email, password) VALUES ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
 INSERT INTO posts (user_id, text) VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎');
 INSERT INTO posts (user_id, text) VALUES (2, '今日の晩御飯はまずかった。 by 田中花子');
 # 太郎から花子の投稿へのいいね

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -1,39 +1,53 @@
 -- テーブル作成
 -- ユーザーテーブル
-CREATE TABLE `users` (
-                         `id` int NOT NULL AUTO_INCREMENT COMMENT 'ID',
-                         `username` VARCHAR(256) NOT NULL COMMENT 'ユーザーID',
-                         `email` VARCHAR(256) NOT NULL COMMENT 'メールアドレス',
-                         `password` BINARY(60) NOT NULL COMMENT 'パスワード (BCrypt)',
-                         `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-                         `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-                         `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
-                         PRIMARY KEY (id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'ユーザーテーブル';
+CREATE TABLE `users`
+(
+    `id`         int          NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    `username`   VARCHAR(256) NOT NULL COMMENT 'ユーザーID',
+    `email`      VARCHAR(256) NOT NULL COMMENT 'メールアドレス',
+    `password`   BINARY(60)   NOT NULL COMMENT 'パスワード (BCrypt)',
+    `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+    `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+    `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci comment = 'ユーザーテーブル';
 -- 投稿テーブル
-CREATE TABLE `posts` (
-                         `id` int NOT NULL AUTO_INCREMENT COMMENT 'ID',
-                         `user_id` int NOT NULL COMMENT '投稿者ユーザーID',
-                         `text` VARCHAR(140) NOT NULL COMMENT '投稿本文',
-                         `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-                         `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-                         `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
-                         PRIMARY KEY (id),
-                         FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = '投稿テーブル';
+CREATE TABLE `posts`
+(
+    `id`         int          NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    `user_id`    int          NOT NULL COMMENT '投稿者ユーザーID',
+    `text`       VARCHAR(140) NOT NULL COMMENT '投稿本文',
+    `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+    `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+    `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+    PRIMARY KEY (id),
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci comment = '投稿テーブル';
 -- いいねテーブル
-CREATE TABLE `favorites` (
-                             `user_id` int NOT NULL COMMENT 'ユーザーID',
-                             `post_id` int NOT NULL COMMENT '投稿ID',
-                             FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
-                             FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),
-                             PRIMARY KEY (`user_id`, `post_id`)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci comment = 'いいねテーブル';
+CREATE TABLE `favorites`
+(
+    `user_id` int NOT NULL COMMENT 'ユーザーID',
+    `post_id` int NOT NULL COMMENT '投稿ID',
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+    FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),
+    PRIMARY KEY (`user_id`, `post_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci comment = 'いいねテーブル';
 
 -- データ挿入
-INSERT INTO users (username, email, password) VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
-INSERT INTO users (username, email, password) VALUES ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
-INSERT INTO posts (user_id, text) VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎');
-INSERT INTO posts (user_id, text) VALUES (2, '今日の晩御飯はまずかった。 by 田中花子');
+INSERT INTO users (username, email, password)
+VALUES ('山田太郎', 'test@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
+INSERT INTO users (username, email, password)
+VALUES ('田中花子', 'test2@example.com', '$2a$08$W0kLGEd0VolF.ZUXlub9ge6iI0QQVbmgtiuCw0ijFJjfo0ZkJmLta');
+INSERT INTO posts (user_id, text)
+VALUES (1, '今日の晩御飯は美味しかった。by 山田太郎');
+INSERT INTO posts (user_id, text)
+VALUES (2, '今日の晩御飯はまずかった。 by 田中花子');
 # 太郎から花子の投稿へのいいね
-INSERT INTO favorites (user_id, post_id) VALUES (1, 2)
+INSERT INTO favorites (user_id, post_id)
+VALUES (1, 2)

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -2,42 +2,42 @@
 -- ユーザーテーブル
 CREATE TABLE `users`
 (
-    `id`         int          NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    `id`         INT          NOT NULL AUTO_INCREMENT COMMENT 'ID',
     `username`   VARCHAR(256) NOT NULL COMMENT 'ユーザーID',
     `email`      VARCHAR(256) NOT NULL COMMENT 'メールアドレス',
     `password`   BINARY(60)   NOT NULL COMMENT 'パスワード (BCrypt)',
-    `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-    `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-    `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+    `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+    `deleted_at` DATETIME DEFAULT NULL COMMENT '削除日時',
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment = 'ユーザーテーブル';
+  COLLATE = utf8mb4_unicode_ci COMMENT = 'ユーザーテーブル';
 -- 投稿テーブル
 CREATE TABLE `posts`
 (
-    `id`         int          NOT NULL AUTO_INCREMENT COMMENT 'ID',
-    `user_id`    int          NOT NULL COMMENT '投稿者ユーザーID',
+    `id`         INT          NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    `user_id`    INT          NOT NULL COMMENT '投稿者ユーザーID',
     `text`       VARCHAR(140) NOT NULL COMMENT '投稿本文',
-    `created_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-    `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-    `deleted_at` datetime DEFAULT NULL COMMENT '削除日時',
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
+    `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+    `deleted_at` DATETIME DEFAULT NULL COMMENT '削除日時',
     PRIMARY KEY (id),
     FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment = '投稿テーブル';
+  COLLATE = utf8mb4_unicode_ci COMMENT = '投稿テーブル';
 -- いいねテーブル
 CREATE TABLE `favorites`
 (
-    `user_id` int NOT NULL COMMENT 'ユーザーID',
-    `post_id` int NOT NULL COMMENT '投稿ID',
+    `user_id` INT NOT NULL COMMENT 'ユーザーID',
+    `post_id` INT NOT NULL COMMENT '投稿ID',
     FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
     FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),
     PRIMARY KEY (`user_id`, `post_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment = 'いいねテーブル';
+  COLLATE = utf8mb4_unicode_ci COMMENT = 'いいねテーブル';
 
 -- データ挿入
 INSERT INTO users (username, email, password)


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/t-ohtsuka89/yumemi-intern-2022/issues/5

## やったこと

* DB初期化用のsqlファイルを追加
* docker環境用にMySQLの設定ファイルを追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

```bash
docker-compose up -d database
docker-compose run --rm flyway-migrate
```
上記コマンドを実行後、MySQL WorkBenchからデータベースに接続して、
意図したテーブルが作成されていること・意図した初期値が挿入されていることを確認

## その他

* パスワードはBCryptでハッシュ化したものを保存するのでBINARY(60)に設定