### PR TITLE
EntityのIDがNULLを許容しないように変更

### DIFF
--- a/src/main/kotlin/com/example/demo/domain/entity/Post.kt
+++ b/src/main/kotlin/com/example/demo/domain/entity/Post.kt
@@ -18,5 +18,5 @@ class Post(
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Int? = null,
+    val id: Int = 0,
 ) : TimeStamp()

--- a/src/main/kotlin/com/example/demo/domain/entity/User.kt
+++ b/src/main/kotlin/com/example/demo/domain/entity/User.kt
@@ -21,5 +21,5 @@ class User(
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null,
+    var id: Int = 0,
 ) : TimeStamp()


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/t-ohtsuka89/yumemi-intern-2022/issues/9

## やったこと

* EntityのIDがNULLを許容しないように変えた

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 直接userRepository.saveを呼び出して、idの初期値が0のUserEntityを登録
* 正しく自動インクリメントが機能することを確認
* ログイン・ログアウトが正しくできることを確認
* 直接postRepository.saveを呼び出して、idの初期値が0のPostEntityを登録
* 正しく自動インクリメントが機能することを確認

## その他

* なし